### PR TITLE
Logging Configuration

### DIFF
--- a/fusion/__init__.py
+++ b/fusion/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""
+Fusion Framework
+================
+
+Copyright © 2022 dronectl. All rights reserved.
+"""

--- a/fusion/__main__.py
+++ b/fusion/__main__.py
@@ -1,12 +1,12 @@
+import os
 import logging
-from fusion.logger.config import load_logging_config, configure_logger
+from fusion.config import Environment as env
+from fusion.logger.config import configure_logger
 
-
-# load logging config
-log_config = load_logging_config(False)
-
+# load dev state
+runtime = env.PROD if os.environ.get('FUSION_DEV') else env.DEV
 # configure logger
-configure_logger(log_config)
+configure_logger(runtime)
 
 logging.basicConfig(level=logging.DEBUG)
 _logger = logging.getLogger(__name__)

--- a/fusion/config.py
+++ b/fusion/config.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""
+Fusion Configuration
+====================
+
+Copyright © 2022 dronectl. All rights reserved.
+"""
+
+from enum import Enum
+
+class Environment(Enum):
+    """
+    Environment Enums. Note these string values must match the configuration file names.
+    """
+    DEV="dev"
+    PROD="prod"

--- a/fusion/logger/config.py
+++ b/fusion/logger/config.py
@@ -1,17 +1,27 @@
+# -*- coding: utf-8 -*-
+"""
+Logging Configuration Helpers
+=============================
+
+Copyright © 2022 dronectl. All rights reserved.
+"""
+
+import yaml
 import logging.config
-from typing import Dict
-from enum import Enum
+
+from pathlib import Path
+from fusion.config import Environment
 
 
-def load_logging_config(prod: bool) -> Dict[str, str]:
+def configure_logger(runtime: Environment) -> None:
     """
-    Load config from yaml config file and translate it to a dictionary
-    """
-    ...
+    Configure python logger from runtime environment
 
-
-def configure_logger(config: Dict[str, str]) -> None:
+    :param runtime: prod or dev runtime enum
+    :type runtime: Environment
     """
-    Configure python logger with dict config
-    """
-    ...
+    logging_conf_path = Path(__file__).parent.joinpath(f'config/{runtime.value}.yaml').resolve()
+    # load dict from path stream
+    log_conf = yaml.safe_load(logging_conf_path.read_text())
+    # configure logger
+    logging.config.dictConfig(log_conf)

--- a/fusion/logger/config/dev.yaml
+++ b/fusion/logger/config/dev.yaml
@@ -4,12 +4,12 @@ disable_existing_loggers: false
 loggers:
   '':
     level: DEBUG
-    handlers: ["console_handler", "file_handler"]
+    handlers: ["console_handler"]
 
 handlers:
   console_handler:
     class: logging.StreamHandler
-    formatter: console
+    formatter: default 
 
 formatters:
   default:

--- a/fusion/logger/config/prod.yaml
+++ b/fusion/logger/config/prod.yaml
@@ -4,12 +4,12 @@ disable_existing_loggers: false
 loggers:
   '':
     level: WARNING
-    handlers: ["console_handler", "file_handler"]
+    handlers: ["console_handler"]
 
 handlers:
   console_handler:
     class: logging.StreamHandler
-    formatter: console
+    formatter: default
 
 formatters:
   default:


### PR DESCRIPTION
# Description
Adding logging configuration to the fusion framework scoped by `dev` or `prod` runtime environments. The default environment is `dev` and will use the dev logging configuration. To override the development environment you must set the `FUSION_DEV` environment variable to `prod`:
```bash
FUSION_DEV=prod python3 -m fusion
```

## Resolutions
 - [x] fix `dev.yaml` and `prod.yaml` bug in handler and formatter key refs
 - [x] implement configurable logging setup on fusion startup.

## Issues
closes #3 